### PR TITLE
Enhance build and setup Make commands for web and admin APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,9 @@
-.PHONY: build run dev clean js-build js-watch templ compose
+.PHONY: build run test templ js-web-build js-web-watch js-admin-watch js-admin-build clean setup compose
+MAKE = make
+
+# Current project uses 'npm' as the package manager for the JS part.
+# Options: npm, pnpm, yarn
+NODE_PKG = npm
 
 # Go commands
 build:
@@ -7,25 +12,38 @@ build:
 run:
 	go run ./cmd/main.go
 
-js-build:
-	cd app/api/web && npm run build
+test:
+	go test ./...
 
 templ:
 	templ generate ./api/web/templates/
 
-js-watch:
-	cd app/api/web && npm run watch
+# JS commands
+js-web-build:
+	cd ./api/web && $(NODE_PKG) run build
 
+js-web-watch:
+	cd ./api/web && $(NODE_PKG) run watch
+
+js-admin-watch:
+	cd ./api/admin && $(NODE_PKG) run watch
+
+js-admin-build:
+	cd ./api/admin && $(NODE_PKG) run build
+
+# Additional commands
 clean:
 	rm -rf bin/
-	rm -rf app/api/web/static/js/dist/
+	rm -rf tmp/
+	rm -rf ./api/web/static/dist/
+	rm -rf ./api/admin/dist/
 
 setup:
-	cd app/api/web && npm install
+	cd ./api/web && $(NODE_PKG) install
+	cd ./api/admin && $(NODE_PKG) install
 	go mod download
-
-test:
-	go test ./...
+	$(MAKE) js-web-build
+	$(MAKE) js-admin-build
 
 compose:
 	docker compose -f compose.dev.yml up --build


### PR DESCRIPTION
The old Makefile uses `app/` prefix instead of `./` in commands and it gives `No such file or directory` error.

I updated and re-ordered the Makefile with 3 categories.
Since it is a template repository, I added the NODE_PKG variable for users who want to try different package managers such as npm,yarn or pnpm.

### Makefile
- Go
  - build
  - run
  - templ
  - test
- JS
Seperated make recipes for each.
  - js-web-build
  - js-web-watch
  - js-admin-watch
  - js-admin-build
- Additional
  - clean: Included the tmp, and JS dist directories.
  - setup: Included js-*-build make recipes.
  - compose

I can also update the documentation on README, if you want.